### PR TITLE
reduced max line length to avoid lint error

### DIFF
--- a/magenta/models/coconet/lib_data.py
+++ b/magenta/models/coconet/lib_data.py
@@ -172,7 +172,8 @@ class Batch(object):
     """
     assert set(kwargs.keys()) == self.keys
     assert all(
-        len(value) == len(list(kwargs.values())[0]) for value in list(kwargs.values()))
+        len(value) == len(list(kwargs.values())[0]) 
+        for value in list(kwargs.values()))
     self.features = kwargs
 
   def get_feed_dict(self, placeholders):


### PR DESCRIPTION
This PR is meant to solve another PR obstacle. Your effort on getting magenta's coconet to work with python 3 and the original datasets is valuable and should be pulled upstream. 
The only problem being a build check that's solved trivially by adding a line break.
I just implemented the suggested change.